### PR TITLE
Fixed API URL generation.

### DIFF
--- a/index.py
+++ b/index.py
@@ -52,12 +52,12 @@ def api_request(action, params=None, method="GET", body=None):
     elif os.getenv("API_VERSION") is not None:
         api_version = os.getenv("API_VERSION")
     else:
-        api_version = ""
+        api_version = "v3"
 
     if CONFIG.has_option("API", "url"):
-        url = "%s%s/api/v3%s/%s" % (CONFIG.get("API", "url"), url_base, api_version, action)
+        url = "%s%s/api/%s/%s" % (CONFIG.get("API", "url"), url_base, api_version, action)
     else:
-        url = "%s%s/api/v3%s/%s" % (os.getenv("URL"), url_base, api_version, action)
+        url = "%s%s/api/%s/%s" % (os.getenv("URL"), url_base, api_version, action)
 
     headers = { 'Content-Type': 'application/json' }
 

--- a/index.py
+++ b/index.py
@@ -55,9 +55,9 @@ def api_request(action, params=None, method="GET", body=None):
         api_version = ""
 
     if CONFIG.has_option("API", "url"):
-        url = "%s%s/api/%s/%s" % (CONFIG.get("API", "url"), url_base, api_version, action)
+        url = "%s%s/api/v3%s/%s" % (CONFIG.get("API", "url"), url_base, api_version, action)
     else:
-        url = "%s%s/api/%s/%s" % (os.getenv("URL"), url_base, api_version, action)
+        url = "%s%s/api/v3%s/%s" % (os.getenv("URL"), url_base, api_version, action)
 
     headers = { 'Content-Type': 'application/json' }
 


### PR DESCRIPTION
It seems Sonarr in the latest versions is a bit more finicky about the API path, or it has just released v4 of the API, and the script did no longer work.
adding v3 to API path generation, and removing extra "/" fixes the issue.